### PR TITLE
Server error on windows

### DIFF
--- a/lib/net/http/server/requests.rb
+++ b/lib/net/http/server/requests.rb
@@ -77,7 +77,7 @@ module Net
             unless uri[:path]
               uri[:path] = '/'
             else
-              uri[:path].insert(0,'/')
+              uri[:path] = uri[:path].to_s.insert(0,'/')
             end
           elsif uri == '*'
             request[:uri] = {}


### PR DESCRIPTION
When requesting a file which is not the root, the server fail here, because uri[:path] is a Parslet::Slice, which does not define insert. Ruby 1.9.1 on windows.

Fix : casting it to the assumed type (String)
