### PR TITLE
Providing an server opening success hook

### DIFF
--- a/lib/net/http/server/daemon.rb
+++ b/lib/net/http/server/daemon.rb
@@ -44,6 +44,9 @@ module Net
         # @option options [#call] :handler
         #   The HTTP Request Handler object.
         #
+        # @option options [Function()] :success_opener
+        #   If the server is successfully opened, this method will be called
+        #
         # @yield [request, socket]
         #   If a block is given, it will be used to process HTTP Requests.
         #
@@ -62,6 +65,12 @@ module Net
           super(port,host,max_connections,log,false,true)
 
           handler(options[:handler],&block)
+          @success_open_callback = options.fetch(:success_opener, lambda {} )
+        end
+
+        def start()
+            super
+            @success_open_callback.call
         end
 
         #


### PR DESCRIPTION
Hello,

  This commit add a new option for server creation, the `:success_opener` which accept a function with no argument and get's called if the server is opened without problem. It's called before the reception of the first request.

  The use case for the feature is as follow :
- using net-http-server as a tiny local webserver
- The need arise to launch multiple instance of the server on different port
- For ease of use the software launch the browser on the local host with the good port

If the server cannot be opened, an exception is raised, and I can try it on an other port, if it's ok, the server would just wait for a request. The callback allow to launch the browser.
