### PR TITLE
Update requests.rb

### DIFF
--- a/lib/net/http/server/requests.rb
+++ b/lib/net/http/server/requests.rb
@@ -22,7 +22,7 @@ module Net
         #   The raw HTTP Request or `nil` if the Request was malformed.
         #
         def read_request(stream)
-          buffer = ''
+          buffer = +''
 
           begin
             request_line = stream.readline("\r\n")


### PR DESCRIPTION
Mark mutable String to prevent runtime warnings in Ruby 3.4:

```
net-http-server-0.2.3/lib/net/http/server/requests.rb:33: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```